### PR TITLE
add gbif in metadata

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -26,7 +26,7 @@ repository=https://github.com/kartoza/SpeciesExplorer
 # changelog=
 
 # Tags are comma separated with spaces allowed
-tags=biodiversity
+tags=biodiversity,gbif
 
 homepage=https://github.com/kartoza/SpeciesExplorer
 category=Web


### PR DESCRIPTION
Typing `gbif` in the plugin manager doesn't show this plugin. It shows only another GBIF plugin.